### PR TITLE
Division by 10 changed with division by binning factor

### DIFF
--- a/hypso/hypso/HypsoBase.py
+++ b/hypso/hypso/HypsoBase.py
@@ -661,7 +661,9 @@ class HypsoBase:
                                                 image_height=self.image_height,
                                                 image_width=self.image_width,
                                                 frame_count=self.frame_count,
-                                                rad_coeffs=self.rad_coeffs)
+                                                bin_factor=self.bin_factor,
+                                                rad_coeffs=self.rad_coeffs
+                                                )
 
         if self.smile_coeffs is not None:
             if smile:

--- a/hypso/hypso/calibration/radiometric.py
+++ b/hypso/hypso/calibration/radiometric.py
@@ -7,6 +7,7 @@ def run_radiometric_calibration(cube: np.ndarray,
                                 image_height: int,
                                 image_width: int,
                                 frame_count: int,
+                                bin_factor: int,
                                 rad_coeffs: np.ndarray) -> np.ndarray:
     """
     Radiometrically Calibrate the Raw Cube (digital counts) to Radiance
@@ -37,8 +38,8 @@ def run_radiometric_calibration(cube: np.ndarray,
         cube_rad_calibrated[i, :, :] = frame_rad_calibrated
 
 
-    # TODO: The factor by 10 is to fix a bug in which the coeff have a factor of 10
-    cube_rad_calibrated = cube_rad_calibrated / 10
+    # Onboard pixels are only summed, not divied, thus this division is needed 
+    cube_rad_calibrated = cube_rad_calibrated / bin_factor
 
 
     return cube_rad_calibrated


### PR DESCRIPTION
Semantic Versioning Change Type: Patch

**Summary of the pull request for the changelog**
Division by 10 changed with division by binning factor in radiometric calibration.

**What issues are related to this pull request?**
Incorrect radiometric values because of division by 10 instead of binning factor. Evident in unbinned captures. 

**What does your pull request address?**
Previously a division by 10 was done when doing radiometric calibration with the reason that the coefficients had a bug that made them factor of 10 higher. Now it has been concluded that this was likely due to not dividing by the binning factor. So the factor of 10 is changed with the binning factor. In fact when processing unbinned captures it is evident that the captures have an offset equal to 10, pointing to the issue. 

**Describe potential caveats of the pull request, if any**
A clear and concise description of any caveats to the solutions or features you've added.

**How to test the pull request**
Not possible

**Additional context and media**

