### PR TITLE
made 'moved' default of coeff_type for l1bs

### DIFF
--- a/hypso/hypso/HypsoBase.py
+++ b/hypso/hypso/HypsoBase.py
@@ -1144,13 +1144,17 @@ class HypsoBase:
 
 
 
-    def generate_l1c_cube(self, coeff_type: str = None, **kwargs) -> None:
+    def generate_l1c_cube(self, coeff_type: str = None, use_direct_georef=True, **kwargs) -> None:
         
         print("[INFO] Generating L1c cube")
         if self.l1b_cube is None:
             self.generate_l1b_cube(coeff_type=coeff_type, **kwargs)
+
+        if use_direct_georef:
+            self.run_direct_georeferencing()
+        else:
+            self.run_georeferencing()
         
-        self.run_georeferencing()
         
         return None
 

--- a/hypso/hypso/HypsoBase.py
+++ b/hypso/hypso/HypsoBase.py
@@ -1132,7 +1132,7 @@ class HypsoBase:
         return solar_zenith_angles, solar_azimuth_angles, sat_zenith_angles, sat_azimuth_angles, relative_azimuth_angles
 
 
-    def generate_l1b_cube(self, coeff_type: str = None, **kwargs) -> None:
+    def generate_l1b_cube(self, coeff_type: str = 'moved', **kwargs) -> None:
 
         print("[INFO] Generating L1b cube")
         if self.l1a_cube is None:


### PR DESCRIPTION
Semantic Versioning Change Type: Major/Minor/**Patch** (https://semver.org/)

**Summary of the pull request for the changelog**
generate_l1b_cube() is changed to use coef_type 'moved' as the default 

**What issues are related to this pull request?**
generate_l1b_cube() used coef_type None as a default, which is not supported by the rest of the package

**What does your pull request address?**
see above

**Describe potential caveats of the pull request, if any**
I've only tested in opening 1 image

**How to test the pull request**
1. install hypso package
2. generate an l1b cube
